### PR TITLE
Simplified .travis.yml lint call

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,4 @@ before_install:
   - npm install
 
 script:
-  - rake lint:styles
-  - rake lint:javascript
+  - rake lint


### PR DESCRIPTION
Issue: N/A

Description:

Now on Travis only `rake lint` is called instead of calling 2 different commands

Testing steps:

Let the PR run on Travis

Checklist:

- [ ] Spec tests are passing on CI
- [ ] `rake lint` does not return any warnings
- [ ] Tested manually