### PR TITLE
Fix romanian translation

### DIFF
--- a/_i18n/ro.yml
+++ b/_i18n/ro.yml
@@ -1431,7 +1431,7 @@ pages:
       articles:
         - name: well_grounded
           title: "The Well-Grounded Rubyist"
-          description: "The Well-Grounded Rubyist", Ediția a doua se adresează atât
+          description: The Well-Grounded Rubyist, Ediția a doua se adresează atât
             nou-veniților programatorilor Ruby, cât și programatorilor Ruby care doresc
             să-și aprofundeze înțelegerea limbii. Această ediție frumoasă și complet
             revizuită include acoperirea caracteristicilor noi în Ruby 2.1, precum și


### PR DESCRIPTION
Issue: [#<ID>]

Description:

Fixed RO translation, because there was error in ro.yml

Testing steps:

Tried to build: `jekyl serve`, got ```jekyll 3.8.6 | Error:  (../betterdocs/_i18n/ro.yml): did not find expected key while parsing a block mapping at line 1432 column 11'```
After fix it's gone

Checklist:

- [x] Spec tests are passing on CI
- [x] `rake lint` does not return any warnings
- [x] Tested manually

Screenshots:

Provide screenshots of implemented functionality if situation required
